### PR TITLE
fix(employees): correct per-hour calculation in employees list

### DIFF
--- a/src/components/list/employees/Employees.tsx
+++ b/src/components/list/employees/Employees.tsx
@@ -7,12 +7,10 @@
  * @version 0.0.1
  */
 
-import { useEmployeeState, useShiftState } from "@/store/zustand";
-import { calcPerHour } from "@/utils/number";
+import { useEmployeeState } from "@/store/zustand";
 import EmployeeItem from "./Item";
 
 const EmployeesList = () => {
-  const { data: shift } = useShiftState();
   const { items: employees } = useEmployeeState();
 
   if (employees.length === 0) {
@@ -27,12 +25,7 @@ const EmployeesList = () => {
     <ul className="w-full mb-6 divide-y divide-gray-200 dark:divide-gray-700">
       {employees.map((employee, index) => (
         <li key={index} className="py-2">
-          <EmployeeItem
-            employee={{
-              ...employee,
-              perHour: calcPerHour(employee.hours, shift.tips),
-            }}
-          />
+          <EmployeeItem employee={employee} />
         </li>
       ))}
     </ul>

--- a/src/components/list/employees/Item.tsx
+++ b/src/components/list/employees/Item.tsx
@@ -7,21 +7,28 @@
  * @version 0.0.1
  */
 
-import { usePreferenceState } from "@/store/zustand";
+import {
+  useEmployeeState,
+  usePreferenceState,
+  useShiftState,
+} from "@/store/zustand";
 import { Employee } from "@/types/employee";
-import { toILS } from "@/utils/number";
+import { calcHours, calcPerHour, toILS } from "@/utils/number";
 import { parseDecimalToTime } from "@/utils/time";
 import Image from "next/image";
 
 type EmployeeItemProps = {
-  employee: Employee & {
-    perHour: number;
-  };
+  employee: Employee;
 };
 
 const EmployeeItem = (props: EmployeeItemProps) => {
   const { employee } = props;
   const { data: preference } = usePreferenceState();
+  const { data: shift } = useShiftState();
+  const { items: employees } = useEmployeeState();
+
+  const hours = calcHours(employees.map((e) => e.hours));
+  const perHour = calcPerHour(hours, shift.tips);
 
   return (
     <div className="flex items-center space-x-4 rtl:space-x-reverse">
@@ -63,7 +70,7 @@ const EmployeeItem = (props: EmployeeItemProps) => {
         </p>
       </div>
       <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">
-        {toILS(employee.perHour)}
+        {toILS(perHour)}
       </div>
     </div>
   );


### PR DESCRIPTION
# Fix: Correct Per-Hour Calculation in Employees List  

## Issue
Closes #30 

## Changes  
- **Employees List**: Removed per-hour calculation.  
- **Employees Item**: Moved per-hour calculation logic here.  

## Description  
This fix resolves an incorrect per-hour calculation in the employees list. The logic has been moved from the list component to individual employee items to ensure accurate calculations per employee.  

## Future Improvements  
This is a **hotfix workaround** to resolve the issue quickly. However, the **Employees List** component structure needs a full refactor for better maintainability and separation of concerns. A future update should focus on improving the architecture of these components.  


## How to Test  
1. Navigate to the employees list.  
2. Verify that the per-hour calculation is now correctly displayed for each employee.  
3. Check that no redundant calculations exist in the employees list component.  

## Additional Notes  
- Ensures better separation of concerns.  
- Improves data accuracy for employee pay rates. 

